### PR TITLE
UI: Overhaul ItemRulesUI with streamlined interface and windowed rule management

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,126 @@
+# Copilot Instructions for UltimateLoot
+# ===========================
+
+This file provides guidance to GitHub Copilot when working with code in this repository.
+
+## Project Overview
+
+UltimateLoot is a World of Warcraft addon for WoW 3.3.5a (Wrath of the Lich King) that provides intelligent loot management and comprehensive statistics tracking. It handles loot decisions automatically based on configurable criteria and provides detailed analytics about loot behavior.
+
+## Repository Structure
+
+The codebase is organized into the following main directories:
+
+- `Core/`: Core addon functionality and initialization
+- `Modules/`: Feature-specific modules (Events, ItemRules, Tracker, Debug, etc.)
+- `Settings/`: Default profile and configuration settings
+- `UI/`: User interface components (GraphUI, HistoryUI, ItemsUI, etc.)
+- `Lib/`: Third-party libraries (Ace3, LibSharedMedia, LibDBIcon)
+- `Locales/`: Localization files (enUS, deDE)
+
+## Architecture
+
+UltimateLoot is built on the Ace3 addon framework, following an event-driven, modular architecture:
+
+1. **Engine (E)**: Central singleton accessible throughout the codebase
+2. **Modules**: Self-contained feature components registered with the Engine
+3. **Events System**: Custom event bus for internal communication
+4. **Settings**: AceDB-3.0 based profile system
+
+## Key Files and Their Purpose
+
+- `Init.lua`: Entry point that creates the Engine and initializes the addon
+- `Core/Core.lua`: Core functionality setup (localization, database, events)
+- `Modules/UltimateLoot.lua`: Main module handling slash commands and events
+- `Modules/Tracker.lua`: Track and analyze loot decisions
+- `Modules/ItemRules.lua`: Custom rules for specific items
+- `Settings/Profile.lua`: Default settings and configuration
+- `UI/*.lua`: Various UI components for different tabs
+
+## Development Guidelines
+
+### Testing
+
+UltimateLoot includes built-in testing functionality:
+
+```lua
+-- Test loot roll functionality
+/ultimateloot test
+/ultimateloot test roll
+
+-- Test item rules functionality
+/ultimateloot test rules
+```
+
+### Slash Commands
+
+UltimateLoot provides several slash commands for development and testing:
+
+```
+/ultimateloot or /ul - Main command help
+/ul enable|disable - Toggle addon functionality
+/ul show - Open the main interface
+/ul threshold <quality> - Set quality threshold
+/ul passall - Toggle Pass on All mode
+/ul debug - Debug mode toggle
+/ul debugtab - Open debug tab
+```
+
+### Debugging
+
+Debug mode can be enabled through:
+
+1. Slash command: `/ul debug on`
+2. Settings UI: Check "Enable Debug Mode"
+
+While in debug mode:
+- Additional logging is shown in chat
+- The Debug tab becomes available with test functionality
+
+## Data Structure
+
+The core data structure for statistics:
+
+```lua
+stats = {
+    totalHandled = 0,
+    rollsByType = { pass = 0, need = 0, greed = 0 },
+    rollsByQuality = {
+        [0] = { pass = 0, need = 0, greed = 0 }, -- Poor
+        [1] = { pass = 0, need = 0, greed = 0 }, -- Common
+        [2] = { pass = 0, need = 0, greed = 0 }, -- Uncommon
+        [3] = { pass = 0, need = 0, greed = 0 }, -- Rare
+        [4] = { pass = 0, need = 0, greed = 0 }, -- Epic
+        [5] = { pass = 0, need = 0, greed = 0 }  -- Legendary
+    }
+}
+```
+
+## Common Development Tasks
+
+### Adding a New Feature
+
+1. Create a new feature branch from `main`
+2. Create an appropriate module in the `Modules/` directory
+3. Register it with the Engine using `E:NewModule()`
+4. Add UI components in the `UI/` directory if needed
+5. Update settings in `Settings/Profile.lua` for any new options
+6. Add localization strings in `Locales/*.lua` files
+
+### Adding Localization
+
+Add new localization strings to:
+- `Locales/enUS.lua` (required base)
+- `Locales/deDE.lua` (optional German translation)
+
+Example:
+```lua
+L["NEW_STRING_KEY"] = "English text"
+```
+
+## Recent Changes
+
+Recent development (v2.1.0) has focused on:
+- Adding table headers to History tab
+- Improving visual clarity with better font styling
+- Fixing issues with empty history display

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,124 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+UltimateLoot is a World of Warcraft addon for WoW 3.3.5a (Wrath of the Lich King) that provides intelligent loot management and comprehensive statistics tracking. It handles loot decisions automatically based on configurable criteria and provides detailed analytics about loot behavior.
+
+## Repository Structure
+
+The codebase is organized into the following main directories:
+
+- `Core/`: Core addon functionality and initialization
+- `Modules/`: Feature-specific modules (Events, ItemRules, Tracker, Debug, etc.)
+- `Settings/`: Default profile and configuration settings
+- `UI/`: User interface components (GraphUI, HistoryUI, ItemsUI, etc.)
+- `Lib/`: Third-party libraries (Ace3, LibSharedMedia, LibDBIcon)
+- `Locales/`: Localization files (enUS, deDE)
+
+## Architecture
+
+UltimateLoot is built on the Ace3 addon framework, following an event-driven, modular architecture:
+
+1. **Engine (E)**: Central singleton accessible throughout the codebase
+2. **Modules**: Self-contained feature components registered with the Engine
+3. **Events System**: Custom event bus for internal communication
+4. **Settings**: AceDB-3.0 based profile system
+
+## Key Files and Their Purpose
+
+- `Init.lua`: Entry point that creates the Engine and initializes the addon
+- `Core/Core.lua`: Core functionality setup (localization, database, events)
+- `Modules/UltimateLoot.lua`: Main module handling slash commands and events
+- `Modules/Tracker.lua`: Track and analyze loot decisions
+- `Modules/ItemRules.lua`: Custom rules for specific items
+- `Settings/Profile.lua`: Default settings and configuration
+- `UI/*.lua`: Various UI components for different tabs
+
+## Development Guidelines
+
+### Testing
+
+UltimateLoot includes built-in testing functionality:
+
+```lua
+-- Test loot roll functionality
+/ultimateloot test
+/ultimateloot test roll
+
+-- Test item rules functionality
+/ultimateloot test rules
+```
+
+### Slash Commands
+
+UltimateLoot provides several slash commands for development and testing:
+
+```
+/ultimateloot or /ul - Main command help
+/ul enable|disable - Toggle addon functionality
+/ul show - Open the main interface
+/ul threshold <quality> - Set quality threshold
+/ul passall - Toggle Pass on All mode
+/ul debug - Debug mode toggle
+/ul debugtab - Open debug tab
+```
+
+### Debugging
+
+Debug mode can be enabled through:
+
+1. Slash command: `/ul debug on`
+2. Settings UI: Check "Enable Debug Mode"
+
+While in debug mode:
+- Additional logging is shown in chat
+- The Debug tab becomes available with test functionality
+
+## Data Structure
+
+The core data structure for statistics:
+
+```lua
+stats = {
+    totalHandled = 0,
+    rollsByType = { pass = 0, need = 0, greed = 0 },
+    rollsByQuality = {
+        [0] = { pass = 0, need = 0, greed = 0 }, -- Poor
+        [1] = { pass = 0, need = 0, greed = 0 }, -- Common
+        [2] = { pass = 0, need = 0, greed = 0 }, -- Uncommon
+        [3] = { pass = 0, need = 0, greed = 0 }, -- Rare
+        [4] = { pass = 0, need = 0, greed = 0 }, -- Epic
+        [5] = { pass = 0, need = 0, greed = 0 }  -- Legendary
+    }
+}
+```
+
+## Common Development Tasks
+
+### Adding a New Feature
+
+1. Create an appropriate module in the `Modules/` directory
+2. Register it with the Engine using `E:NewModule()`
+3. Add UI components in the `UI/` directory if needed
+4. Update settings in `Settings/Profile.lua` for any new options
+5. Add localization strings in `Locales/*.lua` files
+
+### Adding Localization
+
+Add new localization strings to:
+- `Locales/enUS.lua` (required base)
+- `Locales/deDE.lua` (optional German translation)
+
+Example:
+```lua
+L["NEW_STRING_KEY"] = "English text"
+```
+
+## Recent Changes
+
+Recent development (v2.1.0) has focused on:
+- Adding table headers to History tab
+- Improving visual clarity with better font styling
+- Fixing issues with empty history display

--- a/UI/ItemRulesUI.lua
+++ b/UI/ItemRulesUI.lua
@@ -4,7 +4,13 @@ local ItemRulesUI = E:NewModule("ItemRulesUI")
 E.ItemRulesUI = ItemRulesUI
 local AceGUI = E.Libs.AceGUI
 
--- Using UIUtils for shared functionality
+-- Rule type definitions
+local RULE_TYPES = {
+    WHITELIST = { key = "whitelist", color = { 0, 1, 0 }, title = L["ALWAYS_PASS_RULES"] or "Always Pass" },
+    BLACKLIST = { key = "blacklist", color = { 1, 0, 0 }, title = L["NEVER_PASS_RULES"] or "Never Pass" },
+    NEED = { key = "always_need", color = { 0, 0.5, 1 }, title = L["ALWAYS_NEED_RULES"] or "Always Need" },
+    GREED = { key = "always_greed", color = { 1, 0.67, 0 }, title = L["ALWAYS_GREED_RULES"] or "Always Greed" }
+}
 
 -- Helper function to refresh the rules display
 local function RefreshRulesDisplay(self)
@@ -13,6 +19,23 @@ local function RefreshRulesDisplay(self)
     end
 end
 
+-- Helper function to get total rule count
+local function GetRuleCount()
+    if not E.ItemRules then return 0 end
+    
+    local allRules = E.ItemRules:GetRules()
+    local totalCount = 0
+    
+    for ruleType, rules in pairs(allRules) do
+        if rules then
+            totalCount = totalCount + #rules
+        end
+    end
+    
+    return totalCount
+end
+
+-- Main tab function
 function ItemRulesUI:CreateItemRulesTab(container)
     -- Store container for refreshing
     self.currentContainer = container
@@ -20,92 +43,147 @@ function ItemRulesUI:CreateItemRulesTab(container)
     -- Clear container to ensure clean refresh
     container:ReleaseChildren()
 
+    -- Create header with title and controls
+    self:CreateHeader(container)
+    
     -- Main scroll frame using UIUtils
     local scrollFrame = E.UIUtils:CreateScrollFrame(container)
+    self.scrollFrame = scrollFrame
 
-    -- Item Rules Enable/Disable
-    local enableGroup = AceGUI:Create("InlineGroup")
-    enableGroup:SetTitle(L["ITEM_RULES_SYSTEM"])
-    enableGroup:SetFullWidth(true)
-    enableGroup:SetLayout("Flow")
-    scrollFrame:AddChild(enableGroup)
+    -- If module is disabled, show message and return
+    if not E.ItemRules or not E.ItemRules:IsEnabled() then
+        local disabledGroup = AceGUI:Create("InlineGroup")
+        disabledGroup:SetTitle(L["ITEM_RULES_SYSTEM"])
+        disabledGroup:SetFullWidth(true)
+        disabledGroup:SetLayout("Flow")
+        scrollFrame:AddChild(disabledGroup)
+        
+        local disabledLabel = AceGUI:Create("Label")
+        disabledLabel:SetText("|cff888888" .. L["ITEM_RULES_DISABLED"] .. "|r")
+        disabledLabel:SetFullWidth(true)
+        disabledGroup:AddChild(disabledLabel)
+        return
+    end
+    
+    -- Show add rule form
+    self:CreateAddRuleForm(scrollFrame)
+    
+    -- Rules summary
+    self:CreateRulesSummary(scrollFrame)
+end
 
+-- Create the header with title and controls
+function ItemRulesUI:CreateHeader(container)
+    -- Header group
+    local headerGroup = AceGUI:Create("SimpleGroup")
+    headerGroup:SetFullWidth(true)
+    headerGroup:SetLayout("Flow")
+    container:AddChild(headerGroup)
+    
+    -- Title
+    local titleText = AceGUI:Create("Label")
+    titleText:SetText(L["ITEM_RULES_SYSTEM"])
+    titleText:SetFontObject(GameFontNormalLarge)
+    titleText:SetWidth(200)
+    headerGroup:AddChild(titleText)
+    
+    -- Enable checkbox
     local enabledCheckbox = AceGUI:Create("CheckBox")
     enabledCheckbox:SetLabel(L["ENABLE_ITEM_RULES"])
-    enabledCheckbox:SetDescription(L["ENABLE_ITEM_RULES_DESC"])
     enabledCheckbox:SetValue(E.ItemRules and E.ItemRules:IsEnabled() or false)
-    enabledCheckbox:SetFullWidth(true)
+    enabledCheckbox:SetWidth(200)
     enabledCheckbox:SetCallback("OnValueChanged", function(widget, event, value)
         if E.ItemRules then
             E.ItemRules:SetEnabled(value)
             RefreshRulesDisplay(self)
         end
     end)
-    enableGroup:AddChild(enabledCheckbox)
+    headerGroup:AddChild(enabledCheckbox)
+    
+    -- Test rules button
+    local testButton = AceGUI:Create("Button")
+    testButton:SetText(L["TEST_RULES"])
+    testButton:SetWidth(100)
+    testButton:SetCallback("OnClick", function()
+        if E.UltimateLoot and E.UltimateLoot.TestItemRules then
+            E.UltimateLoot:TestItemRules()
+        end
+    end)
+    headerGroup:AddChild(testButton)
+    
+    -- Description
+    local descGroup = AceGUI:Create("SimpleGroup")
+    descGroup:SetFullWidth(true)
+    descGroup:SetLayout("Flow")
+    container:AddChild(descGroup)
+    
+    local descText = AceGUI:Create("Label")
+    descText:SetText(L["ITEM_RULES_DESC"] or "Configure automatic rules for handling specific items when loot rolls appear")
+    descText:SetFullWidth(true)
+    descText:SetFontObject(GameFontNormalSmall)
+    descGroup:AddChild(descText)
+    
+    -- Add horizontal line
+    local line = AceGUI:Create("Label")
+    line:SetText("")
+    line:SetFullWidth(true)
+    line:SetHeight(8)
+    container:AddChild(line)
+end
 
-    if not E.ItemRules or not E.ItemRules:IsEnabled() then
-        local disabledLabel = AceGUI:Create("Label")
-        disabledLabel:SetText("|cff888888" .. L["ITEM_RULES_DISABLED"] .. "|r")
-        disabledLabel:SetFullWidth(true)
-        enableGroup:AddChild(disabledLabel)
-        return
-    end
-
-    -- Add New Rule Section (only shown when enabled)
+-- Create the add rule form
+function ItemRulesUI:CreateAddRuleForm(container)
     local addGroup = AceGUI:Create("InlineGroup")
     addGroup:SetTitle(L["ADD_NEW_RULE"])
     addGroup:SetFullWidth(true)
     addGroup:SetLayout("Flow")
-    scrollFrame:AddChild(addGroup)
-
-    -- Item input field
+    container:AddChild(addGroup)
+    
+    -- Create a 2-column layout
+    local leftColumn = AceGUI:Create("SimpleGroup")
+    leftColumn:SetWidth(300)
+    leftColumn:SetLayout("Flow")
+    addGroup:AddChild(leftColumn)
+    
+    local rightColumn = AceGUI:Create("SimpleGroup")
+    rightColumn:SetWidth(300)
+    rightColumn:SetLayout("Flow")
+    addGroup:AddChild(rightColumn)
+    
+    -- Left column: Item input and rule type
     local itemInput = AceGUI:Create("EditBox")
     itemInput:SetLabel(L["ITEM_NAME_OR_LINK"])
     itemInput:SetText("")
-    itemInput:SetWidth(300)
-    itemInput:SetCallback("OnTextChanged", function(widget, event, text)
-        -- Could add real-time validation here
-    end)
-    addGroup:AddChild(itemInput)
-
-    -- Rule type dropdown
+    itemInput:SetFullWidth(true)
+    leftColumn:AddChild(itemInput)
+    
     local ruleTypeDropdown = AceGUI:Create("Dropdown")
     ruleTypeDropdown:SetLabel(L["RULE_TYPE"])
     ruleTypeDropdown:SetList({
-        whitelist = "|cff00ff00" .. L["ALWAYS_PASS"] .. "|r - " .. L["ALWAYS_PASS_DESC"],
-        blacklist = "|cffff0000" .. L["NEVER_PASS"] .. "|r - " .. L["NEVER_PASS_DESC"],
-        always_need = "|cff0080ff" .. L["ALWAYS_NEED"] .. "|r - " .. L["ALWAYS_NEED_DESC"],
-        always_greed = "|cffffaa00" .. L["ALWAYS_GREED"] .. "|r - " .. L["ALWAYS_GREED_DESC"]
+        whitelist = "|cff00ff00" .. L["ALWAYS_PASS"] .. "|r",
+        blacklist = "|cffff0000" .. L["NEVER_PASS"] .. "|r",
+        always_need = "|cff0080ff" .. L["ALWAYS_NEED"] .. "|r",
+        always_greed = "|cffffaa00" .. L["ALWAYS_GREED"] .. "|r"
     })
     ruleTypeDropdown:SetValue("whitelist")
-    ruleTypeDropdown:SetWidth(250)
-    addGroup:AddChild(ruleTypeDropdown)
+    ruleTypeDropdown:SetFullWidth(true)
+    leftColumn:AddChild(ruleTypeDropdown)
     
-    -- Advanced options section
-    local optionsGroup = AceGUI:Create("SimpleGroup")
-    optionsGroup:SetFullWidth(true)
-    optionsGroup:SetLayout("Flow")
-    addGroup:AddChild(optionsGroup)
-    
-    -- Pattern matching checkbox
+    -- Right column: Options
     local patternMatchCheck = AceGUI:Create("CheckBox")
     patternMatchCheck:SetLabel(L["USE_PATTERN"] or "Use pattern matching")
-    patternMatchCheck:SetDescription(L["USE_PATTERN_DESC"] or "Use Lua pattern matching for more flexible item name rules")
     patternMatchCheck:SetValue(false)
-    patternMatchCheck:SetWidth(200)
-    optionsGroup:AddChild(patternMatchCheck)
+    patternMatchCheck:SetFullWidth(true)
+    patternMatchCheck:SetDescription(L["USE_PATTERN_DESC"] or "Use Lua pattern matching for more flexible item name rules")
+    rightColumn:AddChild(patternMatchCheck)
     
-    -- Note field
-    local noteInput = AceGUI:Create("EditBox")
-    noteInput:SetLabel(L["RULE_NOTE"] or "Rule Note")
-    noteInput:SetText("")
-    noteInput:SetWidth(300)
-    noteInput:SetCallback("OnTextChanged", function(widget, event, text)
-        -- Optional validation
-    end)
-    optionsGroup:AddChild(noteInput)
-
-    -- Add rule button
+    -- Button group (bottom of form)
+    local buttonGroup = AceGUI:Create("SimpleGroup")
+    buttonGroup:SetFullWidth(true)
+    buttonGroup:SetLayout("Flow")
+    addGroup:AddChild(buttonGroup)
+    
+    -- Add button
     local addButton = AceGUI:Create("Button")
     addButton:SetText(L["ADD_RULE"])
     addButton:SetWidth(100)
@@ -113,12 +191,7 @@ function ItemRulesUI:CreateItemRulesTab(container)
         local itemText = itemInput:GetText()
         local ruleType = ruleTypeDropdown:GetValue()
         local usePattern = patternMatchCheck:GetValue()
-        local note = noteInput:GetText()
         
-        if not note or note:trim() == "" then
-            note = nil  -- Don't store empty notes
-        end
-
         if not itemText or itemText:trim() == "" then
             E:Print("Please enter an item name or link.")
             return
@@ -155,8 +228,7 @@ function ItemRulesUI:CreateItemRulesTab(container)
 
         -- Add the rule with options
         local options = {
-            usePattern = usePattern,
-            note = note
+            usePattern = usePattern
         }
         
         local success, message = E.ItemRules:AddItemRule(ruleType, itemName, itemLink, itemId, options)
@@ -167,47 +239,78 @@ function ItemRulesUI:CreateItemRulesTab(container)
                 itemName, 
                 usePattern and " (pattern matching)" or ""))
             itemInput:SetText("")
-            noteInput:SetText("")
             patternMatchCheck:SetValue(false)
             RefreshRulesDisplay(self)
+            
+            -- If rules window is open, refresh it
+            if self.rulesWindow and self.rulesWindow.frame:IsShown() then
+                self:ShowRulesWindow()
+            end
         else
             E:Print(string.format("Failed to add rule: %s", message))
         end
     end)
-    addGroup:AddChild(addButton)
-
+    buttonGroup:AddChild(addButton)
+    
     -- Clear button
     local clearButton = AceGUI:Create("Button")
     clearButton:SetText(L["CLEAR"])
     clearButton:SetWidth(80)
     clearButton:SetCallback("OnClick", function()
         itemInput:SetText("")
-        noteInput:SetText("")
         patternMatchCheck:SetValue(false)
     end)
-    addGroup:AddChild(clearButton)
+    buttonGroup:AddChild(clearButton)
+end
 
-    -- Existing Rules Display
-    self:CreateRulesList(scrollFrame)
-
-    -- Management Buttons (only shown when enabled)
-    local managementGroup = AceGUI:Create("InlineGroup")
-    managementGroup:SetTitle(L["RULE_MANAGEMENT"])
-    managementGroup:SetFullWidth(true)
-    managementGroup:SetLayout("Flow")
-    scrollFrame:AddChild(managementGroup)
-
-    -- Test rules button
-    local testButton = AceGUI:Create("Button")
-    testButton:SetText(L["TEST_RULES"])
-    testButton:SetWidth(100)
-    testButton:SetCallback("OnClick", function()
-        if E.UltimateLoot and E.UltimateLoot.TestItemRules then
-            E.UltimateLoot:TestItemRules()
+-- Create the rules summary section
+function ItemRulesUI:CreateRulesSummary(container)
+    local summaryGroup = AceGUI:Create("InlineGroup")
+    summaryGroup:SetTitle(L["RULES_SUMMARY"] or "Rules Summary")
+    summaryGroup:SetFullWidth(true)
+    summaryGroup:SetLayout("Flow")
+    container:AddChild(summaryGroup)
+    
+    local allRules = E.ItemRules:GetRules()
+    local totalRules = GetRuleCount()
+    
+    if totalRules == 0 then
+        E.UIUtils:ShowEmptyState(summaryGroup, L["NO_RULES_CONFIGURED"])
+    else
+        -- Summary text
+        local summaryText = AceGUI:Create("Label")
+        summaryText:SetText(L["TOTAL_RULES"] .. ": " .. totalRules)
+        summaryText:SetFullWidth(true)
+        summaryText:SetFontObject(GameFontNormal)
+        summaryGroup:AddChild(summaryText)
+        
+        -- Rule type breakdown
+        for _, ruleInfo in pairs(RULE_TYPES) do
+            local rules = allRules[ruleInfo.key] or {}
+            local count = #rules
+            
+            local ruleTypeGroup = AceGUI:Create("SimpleGroup")
+            ruleTypeGroup:SetLayout("Flow")
+            ruleTypeGroup:SetWidth(200)
+            summaryGroup:AddChild(ruleTypeGroup)
+            
+            local ruleTypeLabel = AceGUI:Create("Label")
+            ruleTypeLabel:SetText(ruleInfo.title .. ": " .. count)
+            ruleTypeLabel:SetWidth(180)
+            ruleTypeLabel:SetColor(unpack(ruleInfo.color))
+            ruleTypeGroup:AddChild(ruleTypeLabel)
         end
+    end
+    
+    -- Manage Rules button
+    local manageButton = AceGUI:Create("Button")
+    manageButton:SetText(L["MANAGE_RULES"] or "Manage Rules")
+    manageButton:SetWidth(150)
+    manageButton:SetCallback("OnClick", function()
+        self:ShowRulesWindow()
     end)
-    managementGroup:AddChild(testButton)
-
+    summaryGroup:AddChild(manageButton)
+    
     -- Clear all rules button (with confirmation)
     local clearAllButton = AceGUI:Create("Button")
     clearAllButton:SetText(L["CLEAR_ALL_RULES"])
@@ -218,188 +321,233 @@ function ItemRulesUI:CreateItemRulesTab(container)
                 E.ItemRules:ClearRules()
                 E:Print("All item rules cleared.")
                 RefreshRulesDisplay(self)
+                
+                -- If rules window is open, close it
+                if self.rulesWindow and self.rulesWindow.frame:IsShown() then
+                    self.rulesWindow:Release()
+                    self.rulesWindow = nil
+                end
             end
         end)
     end)
-    managementGroup:AddChild(clearAllButton)
+    summaryGroup:AddChild(clearAllButton)
 end
 
-function ItemRulesUI:CreateRulesList(container)
-    if not E.ItemRules then return end
-
+-- Create and show the rules management window
+function ItemRulesUI:ShowRulesWindow()
+    -- If window exists, release it first
+    if self.rulesWindow then
+        self.rulesWindow:Release()
+        self.rulesWindow = nil
+    end
+    
+    -- Create window frame
+    local window = AceGUI:Create("Frame")
+    window:SetTitle(L["ITEM_RULES_MANAGER"] or "Item Rules Manager")
+    window:SetLayout("Flow")
+    window:SetWidth(600)
+    window:SetHeight(500)
+    
+    self.rulesWindow = window
+    self.activeRuleType = self.activeRuleType or "whitelist"
+    
+    -- Create tabs for rule types
+    local tabGroup = AceGUI:Create("SimpleGroup")
+    tabGroup:SetFullWidth(true)
+    tabGroup:SetHeight(30)
+    tabGroup:SetLayout("Flow")
+    window:AddChild(tabGroup)
+    
+    -- Create tab buttons
+    for _, ruleInfo in pairs(RULE_TYPES) do
+        local allRules = E.ItemRules:GetRules()
+        local rules = allRules[ruleInfo.key] or {}
+        local count = #rules
+        
+        local tabButton = AceGUI:Create("Button")
+        local isActive = self.activeRuleType == ruleInfo.key
+        
+        tabButton:SetText(ruleInfo.title .. " (" .. count .. ")")
+        tabButton:SetWidth(140)
+        
+        -- Style active tab differently
+        if isActive then
+            tabButton:SetBackdropColor(ruleInfo.color[1], ruleInfo.color[2], ruleInfo.color[3], 0.5)
+        end
+        
+        tabButton:SetCallback("OnClick", function()
+            self.activeRuleType = ruleInfo.key
+            self:ShowRulesWindow()
+        end)
+        
+        tabGroup:AddChild(tabButton)
+    end
+    
+    -- Create rules grid
+    local scrollFrame = AceGUI:Create("ScrollFrame")
+    scrollFrame:SetLayout("Flow")
+    scrollFrame:SetFullWidth(true)
+    scrollFrame:SetFullHeight(true)
+    window:AddChild(scrollFrame)
+    
+    -- Get rules for active type
     local allRules = E.ItemRules:GetRules()
-    local hasAnyRules = false
-
-    -- Check if we have any rules at all
-    for ruleType, rules in pairs(allRules) do
-        if rules and #rules > 0 then
-            hasAnyRules = true
+    local activeRules = allRules[self.activeRuleType] or {}
+    local activeRuleInfo = nil
+    
+    -- Find the active rule info
+    for _, ruleInfo in pairs(RULE_TYPES) do
+        if ruleInfo.key == self.activeRuleType then
+            activeRuleInfo = ruleInfo
             break
         end
     end
-
-    if not hasAnyRules then
-        local noRulesGroup = AceGUI:Create("InlineGroup")
-        noRulesGroup:SetTitle(L["CURRENT_RULES"])
-        noRulesGroup:SetFullWidth(true)
-        noRulesGroup:SetLayout("Flow")
-        container:AddChild(noRulesGroup)
-
-        E.UIUtils:ShowEmptyState(noRulesGroup, L["NO_RULES_CONFIGURED"])
-        return
-    end
-
-    -- Create sections for each rule type
-    local ruleTypeInfo = {
-        whitelist = { title = L["ALWAYS_PASS_RULES"], color = { 0, 1, 0 }, desc = L["ALWAYS_PASS_RULES_DESC"] },
-        blacklist = { title = L["NEVER_PASS_RULES"], color = { 1, 0, 0 }, desc = L["NEVER_PASS_RULES_DESC"] },
-        always_need = { title = L["ALWAYS_NEED_RULES"], color = { 0, 0.5, 1 }, desc = L["ALWAYS_NEED_RULES_DESC"] },
-        always_greed = { title = L["ALWAYS_GREED_RULES"], color = { 1, 0.67, 0 }, desc = L["ALWAYS_GREED_RULES_DESC"] }
-    }
-
-    for ruleType, info in pairs(ruleTypeInfo) do
-        local rules = allRules[ruleType]
-        if rules and #rules > 0 then
-            local ruleGroup = AceGUI:Create("InlineGroup")
-            ruleGroup:SetTitle(info.title .. " (" .. #rules .. ")")
-            ruleGroup:SetFullWidth(true)
-            ruleGroup:SetLayout("Flow")
-            container:AddChild(ruleGroup)
-
-            -- Description
-            local descLabel = AceGUI:Create("Label")
-            descLabel:SetText(info.desc)
-            descLabel:SetColor(unpack(info.color))
-            descLabel:SetFullWidth(true)
-            descLabel:SetFontObject(GameFontNormalSmall)
-            ruleGroup:AddChild(descLabel)
-
-            -- Rules list
-            for i, rule in ipairs(rules) do
-                local ruleFrame = AceGUI:Create("SimpleGroup")
-                ruleFrame:SetLayout("Flow")
-                ruleFrame:SetFullWidth(true)
-                ruleGroup:AddChild(ruleFrame)
-
-                -- Item name/link
-                local itemLabel = AceGUI:Create("InteractiveLabel")
-                local displayText = rule.link or rule.name or "Unknown Item"
+    
+    if #activeRules == 0 then
+        -- Show empty state if no rules
+        E.UIUtils:ShowEmptyState(scrollFrame, L["NO_RULES_OF_TYPE"] or "No rules of this type configured")
+    else
+        -- Create grid container
+        local gridContainer = AceGUI:Create("SimpleGroup")
+        gridContainer:SetFullWidth(true)
+        gridContainer:SetLayout("Flow")
+        scrollFrame:AddChild(gridContainer)
+        
+        -- Title and description
+        local titleText = AceGUI:Create("Label")
+        titleText:SetText(activeRuleInfo.title)
+        titleText:SetColor(unpack(activeRuleInfo.color))
+        titleText:SetFontObject(GameFontNormalLarge)
+        titleText:SetFullWidth(true)
+        gridContainer:AddChild(titleText)
+        
+        -- Create grid of rule cards
+        local cardsPerRow = 2
+        local currentRow = nil
+        
+        for i, rule in ipairs(activeRules) do
+            -- Create new row if needed
+            if (i-1) % cardsPerRow == 0 then
+                currentRow = AceGUI:Create("SimpleGroup")
+                currentRow:SetFullWidth(true)
+                currentRow:SetLayout("Flow")
+                gridContainer:AddChild(currentRow)
+            end
+            
+            -- Create card for this rule
+            local card = AceGUI:Create("InlineGroup")
+            card:SetWidth(270)
+            card:SetLayout("List")
+            
+            -- Style card based on rule type
+            local r, g, b = unpack(activeRuleInfo.color)
+            card.frame:SetBackdropBorderColor(r, g, b, 0.7)
+            
+            currentRow:AddChild(card)
+            
+            -- Item name/link with icon if possible
+            local itemLabel = AceGUI:Create("InteractiveLabel")
+            local displayText = rule.link or rule.name or "Unknown Item"
+            
+            -- Add pattern indicator if it's a pattern match rule
+            if rule.usePattern then
+                displayText = "|cffff8c00[Pattern]|r " .. displayText
+            end
+            
+            -- Add ID if available
+            if rule.itemId then
+                displayText = displayText .. " |cff7f7f7f[" .. rule.itemId .. "]|r"
+            end
+            
+            itemLabel:SetText(displayText)
+            itemLabel:SetFullWidth(true)
+            
+            -- Add tooltip for item links
+            if rule.link then
+                E.UIUtils:AddItemTooltip(itemLabel, rule.link)
                 
-                -- Add pattern indicator if it's a pattern match rule
-                if rule.usePattern then
-                    displayText = "|cffff8c00[Pattern]|r " .. displayText
-                end
-                
-                itemLabel:SetText(displayText)
-                itemLabel:SetWidth(240)
-                if rule.link then
-                    itemLabel:SetCallback("OnClick", function()
-                        -- Copy item link to chat
-                        if ChatEdit_GetActiveWindow() then
-                            ChatEdit_GetActiveWindow():Insert(rule.link)
-                        end
-                    end)
-                end
-                ruleFrame:AddChild(itemLabel)
-
-                -- Item ID if available
-                if rule.itemId then
-                    local idLabel = AceGUI:Create("Label")
-                    idLabel:SetText("ID: " .. rule.itemId)
-                    idLabel:SetWidth(60)
-                    idLabel:SetColor(0.7, 0.7, 0.7)
-                    ruleFrame:AddChild(idLabel)
-                end
-                
-                -- Note section
-                local noteGroup = AceGUI:Create("SimpleGroup")
-                noteGroup:SetLayout("Flow")
-                noteGroup:SetWidth(200)
-                ruleFrame:AddChild(noteGroup)
-                
-                -- Note display or placeholder
-                local noteText = rule.note or L["NO_NOTE"]
-                local noteColor = rule.note and {0.6, 0.8, 0.9} or {0.5, 0.5, 0.5}
-                local noteLabel = AceGUI:Create("InteractiveLabel")
-                noteLabel:SetText(rule.note or L["ADD_NOTE"])
-                noteLabel:SetWidth(180)
-                noteLabel:SetColor(unpack(noteColor))
-                
-                -- Edit functionality
-                noteLabel:SetCallback("OnClick", function()
-                    -- Create popup for editing note
-                    StaticPopupDialogs["ULTIMATELOOT_EDIT_NOTE"] = {
-                        text = L["EDIT_NOTE_FOR"] .. (rule.link or rule.name or L["UNKNOWN_ITEM"]),
-                        button1 = L["OKAY"] or "Okay",
-                        button2 = L["CANCEL"] or "Cancel",
-                        hasEditBox = true,
-                        editBoxWidth = 300,
-                        OnShow = function(dialog)
-                            dialog.editBox:SetText(rule.note or "")
-                            dialog.editBox:SetFocus()
-                        end,
-                        OnAccept = function(dialog)
-                            local newNote = dialog.editBox:GetText()
-                            if newNote and newNote:trim() ~= "" then
-                                rule.note = newNote
-                            else
-                                rule.note = nil
-                            end
-                            -- Refresh UI to show updated note
-                            RefreshRulesDisplay(self)
-                            -- Fire event for data update
-                            E:SendMessage("ULTIMATELOOT_ITEM_RULE_UPDATED", {
-                                ruleType = ruleType,
-                                rule = rule
-                            })
-                        end,
-                        timeout = 0,
-                        whileDead = true,
-                        hideOnEscape = true,
-                        preferredIndex = 3,
-                    }
-                    StaticPopup_Show("ULTIMATELOOT_EDIT_NOTE")
-                end)
-                noteGroup:AddChild(noteLabel)
-
-                -- Remove button
-                local removeButton = AceGUI:Create("Button")
-                removeButton:SetText(L["REMOVE"])
-                removeButton:SetWidth(80)
-                removeButton:SetCallback("OnClick", function()
-                    local success, message = E.ItemRules:RemoveItemRule(ruleType, rule.name, rule.link)
-                    if success then
-                        E:Print(string.format("Removed %s rule for %s", ruleType, rule.name or "Unknown"))
-                        RefreshRulesDisplay(self)
-                    else
-                        E:Print(string.format("Failed to remove rule: %s", message))
+                -- Make item link clickable
+                itemLabel:SetCallback("OnClick", function()
+                    if ChatEdit_GetActiveWindow() then
+                        ChatEdit_GetActiveWindow():Insert(rule.link)
                     end
                 end)
-                ruleFrame:AddChild(removeButton)
             end
-
-            -- Clear this type button
-            local clearTypeButton = AceGUI:Create("Button")
-            clearTypeButton:SetText("Clear All " .. info.title)
-            clearTypeButton:SetWidth(150)
-            clearTypeButton:SetCallback("OnClick", function()
-                StaticPopupDialogs["ULTIMATELOOT_CLEAR_RULE_TYPE"] = {
-                    text = string.format(L["CLEAR_RULE_TYPE_CONFIRM"], info.title:lower()),
-                    button1 = L["YES"],
-                    button2 = L["NO"],
-                    OnAccept = function()
-                        E.ItemRules:ClearRules(ruleType)
-                        E:Print(string.format("Cleared all %s rules.", ruleType))
-                        RefreshRulesDisplay(self)
-                    end,
-                    timeout = 0,
-                    whileDead = true,
-                    hideOnEscape = true,
-                    preferredIndex = 3,
-                }
-                StaticPopup_Show("ULTIMATELOOT_CLEAR_RULE_TYPE")
+            card:AddChild(itemLabel)
+            
+            -- Rule info
+            local infoGroup = AceGUI:Create("SimpleGroup")
+            infoGroup:SetLayout("Flow")
+            infoGroup:SetFullWidth(true)
+            card:AddChild(infoGroup)
+            
+            -- Pattern info
+            if rule.usePattern then
+                local patternLabel = AceGUI:Create("Label")
+                patternLabel:SetText(L["PATTERN_MATCHING"] or "Pattern matching: |cffff8c00Enabled|r")
+                patternLabel:SetWidth(200)
+                infoGroup:AddChild(patternLabel)
+            end
+            
+            -- Actions
+            local actionsGroup = AceGUI:Create("SimpleGroup")
+            actionsGroup:SetLayout("Flow")
+            actionsGroup:SetFullWidth(true)
+            card:AddChild(actionsGroup)
+            
+            -- Remove button
+            local removeButton = AceGUI:Create("Button")
+            removeButton:SetText(L["REMOVE"])
+            removeButton:SetWidth(80)
+            removeButton:SetCallback("OnClick", function()
+                local success, message = E.ItemRules:RemoveItemRule(self.activeRuleType, rule.name, rule.link)
+                if success then
+                    E:Print(string.format("Removed %s rule for %s", self.activeRuleType, rule.name or "Unknown"))
+                    self:ShowRulesWindow()
+                    RefreshRulesDisplay(self)
+                else
+                    E:Print(string.format("Failed to remove rule: %s", message))
+                end
             end)
-            ruleGroup:AddChild(clearTypeButton)
+            actionsGroup:AddChild(removeButton)
         end
     end
+    
+    -- Bottom controls
+    local bottomControls = AceGUI:Create("SimpleGroup")
+    bottomControls:SetFullWidth(true)
+    bottomControls:SetLayout("Flow")
+    window:AddChild(bottomControls)
+    
+    -- Clear rules of this type button
+    local clearTypeButton = AceGUI:Create("Button")
+    clearTypeButton:SetText(L["CLEAR_RULES_OF_TYPE"] or "Clear All Rules of This Type")
+    clearTypeButton:SetWidth(200)
+    clearTypeButton:SetCallback("OnClick", function()
+        local ruleTypeTitle = ""
+        for _, ruleInfo in pairs(RULE_TYPES) do
+            if ruleInfo.key == self.activeRuleType then
+                ruleTypeTitle = ruleInfo.title
+                break
+            end
+        end
+        
+        StaticPopupDialogs["ULTIMATELOOT_CLEAR_RULE_TYPE"] = {
+            text = string.format(L["CLEAR_RULE_TYPE_CONFIRM"] or "Are you sure you want to clear all %s rules?", ruleTypeTitle:lower()),
+            button1 = L["YES"] or "Yes",
+            button2 = L["NO"] or "No",
+            OnAccept = function()
+                E.ItemRules:ClearRules(self.activeRuleType)
+                E:Print(string.format("Cleared all %s rules.", self.activeRuleType))
+                self:ShowRulesWindow()
+                RefreshRulesDisplay(self)
+            end,
+            timeout = 0,
+            whileDead = true,
+            hideOnEscape = true,
+            preferredIndex = 3,
+        }
+        StaticPopup_Show("ULTIMATELOOT_CLEAR_RULE_TYPE")
+    end)
+    bottomControls:AddChild(clearTypeButton)
 end


### PR DESCRIPTION
## Summary
- Created a cleaner main tab with compact add rule form
- Added a rules summary section with counts per rule type
- Implemented a separate window for managing rules
- Designed grid-based card layout for rules display
- Removed note functionality for cleaner interface

## Test plan
- Enable Item Rules and verify the new interface displays correctly
- Add rules of each type and verify they appear in rules summary
- Click "Manage Rules" to test the rules window functionality
- Check that grid layout works correctly with multiple rules
- Verify that rules can be removed from both the window display
- Test Clear All buttons both in main UI and rules window

🤖 Generated with [Claude Code](https://claude.ai/code)